### PR TITLE
resource tab, language page fixes, yt link footer

### DIFF
--- a/about/getaccess.mdx
+++ b/about/getaccess.mdx
@@ -1,0 +1,10 @@
+---
+title: Get access
+description: 'Use the self-service console to sign up and start your free trial today'
+mode: "wide"
+---
+
+import GetAccessSnippet from '/snippets/getaccess-snip.mdx';
+
+<GetAccessSnippet/>
+

--- a/about/help.mdx
+++ b/about/help.mdx
@@ -1,0 +1,53 @@
+---
+title: Help
+description: 'Learn about help and support resources'
+mode: "wide"
+---
+
+<Steps titleSize="h3">
+
+    <Step title="Self guided tour">
+        Need a step-by-step guide for getting started? 
+        
+        Check out the quickstart guide:
+        
+        <Card title="Quickstart" icon="rocket-launch" href="/get_started/quickstart/" horizontal="true">
+            Walkthrough and examples on how to authenticate and make your firt API request
+        </Card>
+        
+        <br/>
+    </Step>
+
+    <Step title="AI-powered support">
+        Having trouble finding the information you need? 
+        
+        The AI Agent is ready to help you on both this API documentation site as well as the help center:
+
+        <AccordionGroup>
+            <Accordion title="Ask AI - docs.corti.ai" icon="wand-magic-sparkles"> 
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/TAFbG1Q4AK4?si=grqiYtDxj51vad9u" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </Accordion>
+
+            <Accordion title="Ask AI - help.corti.app" icon="wand-magic-sparkles"> 
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/a2nUzRnnzCU?si=Ev59aG8pnZ-xd_lA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe> 
+            </Accordion>
+        </AccordionGroup>
+        
+        <br/>
+    </Step>
+
+    <Step title="Find answers and guidance from the Corti team">
+
+        The online support center includes detailed help articles, support documentation and ticketing, and access to the security and trust center. You can also contact the Corti team directly. 
+
+        <Card title="Support center" icon="square-question" href="https://help.corti.app/" arrow="true" horizontal="true">
+            View help articles and support documentation, open tickets, and contact the Corti team
+        </Card>
+
+    </Step>
+
+</Steps>
+
+<br/>
+
+<Note>Please don't hesitate to contact us for further support or questions! Please reach out via [help.corti.app](https://help.corti.app).</Note>

--- a/about/languages.mdx
+++ b/about/languages.mdx
@@ -4,36 +4,35 @@ description: 'Learn about how languages are supported in Corti APIs'
 ---
 
 ## Introduction
-Corti foundation models are specifically designed for use in the healthcare domain. While automated speech recognition (ASR) capabilities are continuously refined, a tier system has been introduced to categorize functionality and performance that is available. Selecting language models at the appropriate tier allows you to find the right fit for your needs while balancing capabilities and cost. 
+Corti automated speech recognition (ASR) is specifically designed for use in the healthcare domain. A tier system has been introduced to categorize functionality and performance that is available per language and endpoint. Selecting language models at the appropriate tier allows you to find the right fit for your needs while balancing capabilities and cost. 
 
-The language codes are also used for defining output language in note generation requests. 
+<Tip>The `language codes` listed below are used in API requests for both defining speech recognition language and document generation output language</Tip>
 
+## Corti ASR language tiers 
 
-## Corti ASR tiers 
+| Tier           | Description | Primary use case |
+| :------------- | :---------- | :--- |
+| **Base**       | Enable speech-to-text with a **general medicine model** for various speech-enabled workflows | Automated speech recognition |
+| **Enhanced**   | Base functionality plus **optimized medical terminology recognition** for a variety of specialties, balancing speed, performance, and quality | Ambient documentation workflows |
+| **Premier**    | Enhanced functionality plus the highest accuracy, **lowest latency and most features** (e.g., customized commands, spoken or automated punctuation, and smart formatting) | Robust dictation workflows |
 
-| Tier           |  Description | Primary use case |
-| :------------- |  :---------- | :--- |
-| **Base**       |  Enable speech-to-text with a **general medicine model** for various speech-enabled workflows | Automated speech recognition |
-| **Enhanced**   |  Base functionality plus **optimized medical terminology recognition** for a variety of specialties, balancing speed, performance, and quality | Ambient documentation workflows |
-| **Premier**    |  Enhanced functionality plus the highest accuracy, **lowest latency and most functionality** (e.g., customized commands, user-defined lexicon, spoken or automated punctuation) | Robust dictation workflows |
+## Available language tiers per ASR endpoint 
 
-## Available languages
-
-| Language     | Language Code (BCP47) | Tier availability |
-| :----------- | :-------------------- | :---------------- |
-| English (US) | en                    | Enhanced, Premier |
-| English (UK) | en-GB                 | Enhanced, Premier |
-| Danish       | da                    | Enhanced, Premier (coming soon) |
-| German       | de                    | Enhanced, Premier (coming soon) |
-| Swiss-German | de-CH                 | Enhanced |
-| French       | fr                    | Enhanced |
-| Spanish      | es                    | Base, Enhanced (coming soon) |
-| Swedish      | sv                    | Base, Enhanced (coming soon) |
-| Italian      | it                    | Base |
-| Dutch        | nl                    | Base |
-| Norwegian    | no                    | Base |
-| Portuguese   | pt                    | Base |
-| Arabic       | ar                    | Base (coming soon) |
+| Language     | Language Code<br/>(BCP47) | [Transcribe](/api-reference/transcribe/) | [Stream](/api-reference/stream/) | [Transcripts](/api-reference/transcripts/create-transcript)|
+| :----------- | :-----------------------: | :--- | :--- | :--- |
+| English (US) | en                    | Premier | Premier | Premier | 
+| English (UK) | en-GB                 | Premier | Premier | Premier | 
+| Danish       | da                    | Premier | Premier | Base | 
+| German       | de                    | Premier | Premier | Base | 
+| French       | fr                    | Premier | Premier | Base | 
+| Swiss-German | de-CH                 | Base | Enhanced | Base | 
+| Spanish      | es                    | Base | Base | Base | 
+| Italian      | it                    | Base | Base | Base | 
+| Dutch        | nl                    | Base | Base | Base | 
+| Norwegian    | no                    | Base | Base | Base | 
+| Portuguese   | pt                    | Base | Base | Base | 
+| Swedish      | sv                    | Base | Base | Base | 
+| Arabic       | ar                    | | _coming soon_ | | 
 
 <br/>
-<Note>If you are interested in a language that is not listed here, or need help determining the best language tier for your needs, please [contact us](https://help.corti.ai)</Note>
+<Note>Please [contact us](https://help.corti.app) if you are interested in a language that is not listed here, need help determining the best language tier for your needs, or have questions about how to use language codes in API requests.</Note>

--- a/docs.json
+++ b/docs.json
@@ -84,16 +84,22 @@
         ]
       },
       {
-        "anchor": "Updates",
+        "anchor": "Resources",
         "icon": "gears",
         "groups": [
           {
-            "group": "Updates",
+            "group": "Get Started",
             "pages": [
               "release-notes/overview",
-              "release-notes/fm-updates",
+              "about/help",
+              "about/getaccess"
+            ]
+          },
+          {
+            "group": "Release Notes",
+            "pages": [
               "release-notes/api-updates",
-              "release-notes/language-updates"
+              "release-notes/asr-updates"
             ]
           },
           {
@@ -133,7 +139,7 @@
     },
     "links":[{
       "label": "Support",
-      "href": "https://help.corti.ai/"
+      "href": "https://help.corti.app/"
     }
     ]
   },
@@ -141,8 +147,9 @@
     "socials": {
       "website": "https://www.corti.ai",
       "x": "https://x.com/corti_ai",
+      "linkedin": "https://www.linkedin.com/company/corti",
       "github": "https://github.com/corticph",
-      "linkedin": "https://www.linkedin.com/company/corti"
+      "youtube": "https://www.youtube.com/@cortiai"
     }
   },
   "integrations": {

--- a/release-notes/api-updates.mdx
+++ b/release-notes/api-updates.mdx
@@ -3,7 +3,7 @@ title: "API Updates"
 description: "Updates and improvements to Corti application programming interfaces (API). Detailed API documentation is available [here](/api-reference/)."
 ---
 
-<Update label="2025-04-09" description="Solo v1.5">
+<Update label="2025-04-09">
   New API endpoint, `/transcribe` now available! Use this endpoint for stateless, real-time streaming dictation workflows. See more details [here](/api-reference/transcribe/) in the API reference and [here](/sdk/dictation-sdk/) for access to the Corti Dictation SDK. <br/>
 </Update>
 

--- a/release-notes/asr-updates.mdx
+++ b/release-notes/asr-updates.mdx
@@ -1,14 +1,18 @@
 ---
-title: "Language Updates"
+title: "ASR Updates"
 description: "Updates and improvements to language models supported by Corti automated speech recognition (ASR). Detailed language documentation is availabile [here](/about/languages/)."
 ---
 
+<Update label="2025-05-30" description="Solo v1.5">
+  Danish (da), German (de), and French (fr) Premier language models now available for dictation workflows via /transcribe endpoint. 
+</Update>
+
 <Update label="2025-03-28" description="Solo v1.4">
-  Swiss German (de-CH) Enhanced language model now available. 
+  Swiss German (de-CH) Enhanced language model now available for ambient documentation workflows via /stream endpoint.
 </Update>
 
 <Update label="2025-03-11" description="Solo v1.3">
-  French (fr) Enhanced language model now available. 
+  French (fr) Enhanced language model now available via for ambient document generation workflows /stream endpoint. 
 </Update>
 
 <Update label="2025-03-08">

--- a/release-notes/overview.mdx
+++ b/release-notes/overview.mdx
@@ -1,42 +1,38 @@
 ---
-title: "Overview"
+title: "Welcome to the resource center"
+sidebarTitle: "Welcome"
 description: "Find the latest updates across Corti's products"
 mode: "wide"
 ---
 
-  <Card
-    title="Foundation Model Updates"
-    icon="layer-group"
-    href="/release-notes/fm-updates"
-    horizontal="true"
-  >
-    Learn about the latest capabilities for Corti AI platform and Foundation Models.
-  </Card>
+## Release notes
+
+The release notes pages will detail updates to the Corti AI Platform, which includes the following: 
+
   <CardGroup cols={2}>
   <Card
     title="API Updates"
     icon="rectangle-terminal"
-    href="/release-notes/api-updates"
+    href="/release-notes/api-updates/"
   >
-    Learn about the latest capabilities for Corti application programming interfaces (API), used to access the three Foundation Models.
+    Learn about the latest capabilities for Corti AI platform infrastructure and application programming interfaces (API).
   </Card>
   <Card
-    title="Language Updates"
+    title="ASR Updates"
     icon="microphone"
-    href="/release-notes/language-updates"
+    href="/release-notes/asr-updates/"
   >
-    Learn about the latest capabilities for Corti automated speech recognition (ASR) language models, packaged into releases of Corti Solo foundation model.
+    Learn about the latest capabilities for Corti automated speech recognition (ASR) language models that enable speech-to-text.
   </Card>
   </CardGroup>
-<br/>
-<Info>
-  Looking for documentation on Corti API v1? 
-  
-  Legacy API documentation is still accessible [here](https://docs-legacy.corti.ai/), but we recommend using the latest API documentation for new integrations.
-</Info>
 
-<Info>
-  Looking for release notes for Corti Assistant or Mission Control? 
-  
-  Visit our [Help Center](https://help.corti.ai/).
-</Info>
+---
+
+## Help 
+
+The online support center includes detailed help articles, support documentation and ticketing, security and trust center, and ability to contact the Corti team. 
+
+<Card title="Support center" icon="square-question" href="/about/help/" horizontal="true">
+    View help articles and support documentation, open tickets, and contact the Corti team
+</Card>
+

--- a/release-notes/platform.mdx
+++ b/release-notes/platform.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Foundation Model Updates"
-description: "Updates and improvements to Corti foundation models. More information is available [here](https://www.corti.ai/foundation-models)."
+title: "Release notes"
+description: "Updates and improvements to Corti AI Platform."
 ---
 
 
-<Update label="2025-04-09">
-  New API endpoint, `/transcribe` now available! Use this endpoint for stateless, real-time streaming dictation workflows. See more details [here](/api-reference/transcribe/) in the API reference and [here](/sdk/dictation-sdk/) for access to the Corti Dictation SDK. <br/>
+<Update label="2025-05-30">
+  Updated Danish, German, and French (Premier) language models now available for use in dictation via `/transcribe` endpoint. <br/>
   <Tabs>
     <Tab title="Solo">
-      **Version**: v1.5 
+      **Version**: v1.5
 
       **Endpoints included**: `Interactions`, `Recordings`, `Transcripts`, `Transcribe`
 
@@ -27,6 +27,33 @@ description: "Updates and improvements to Corti foundation models. More informat
       **Endpoints included**: `Stream`, `Facts`, `Codes` 
 
       **Ensemble version included**: Ensemble 1.5
+    </Tab>
+  </Tabs>
+</Update> 
+
+<Update label="2025-04-09">
+  New API endpoint, `/transcribe` now available! Use this endpoint for stateless, real-time streaming dictation workflows. See more details [here](/api-reference/transcribe/) in the API reference and [here](/sdk/dictation-sdk/) for access to the Corti Dictation SDK. <br/>
+  <Tabs>
+    <Tab title="Solo">
+      **Version**: v1.4
+
+      **Endpoints included**: `Interactions`, `Recordings`, `Transcripts`, `Transcribe`
+
+      **Language models included**: en, en-GB, da, de, de-CH, fr, sv, es, nl, no, it, pt 
+    </Tab>
+    <Tab title="Ensemble">
+      **Version**: v1.4
+
+      **Endpoints included**: `Documents`, `Templates`
+
+      **Solo version included**: Solo v1.4
+    </Tab>
+    <Tab title="Symphony">
+      **Version**: v1.4
+
+      **Endpoints included**: `Stream`, `Facts`, `Codes` 
+
+      **Ensemble version included**: Ensemble 1.4
     </Tab>
   </Tabs>
 </Update> 

--- a/snippets/welcome-snip.mdx
+++ b/snippets/welcome-snip.mdx
@@ -27,7 +27,7 @@ This documentation site provides information on how Corti foundation models can 
   </Card>
 </Columns>
 
-<br/>
+---
 
 ### API Reference
 
@@ -52,7 +52,7 @@ This documentation site provides information on how Corti foundation models can 
   </Card>
 </Columns> 
 
-<br/>
+---
 
 ### Help
 


### PR DESCRIPTION
* Changed "Updates" tab to "Resources"
* Added Get Started section on Resource tab so strucutre consistent with Documentation and API Reference tabs
* Added Help walkthrough page, including pointer to quickstart, demo videos for using AI assistant, and link to support center
* Removed platform (foundation model) release notes page - for now
* Added release notes for May ASR updates - German, Danish, French premier 
* Updated languages page so that there are separate columns for each ASR endpoint - necessary, for now while fix is in progress, because model tiers are not the same across all endpoint 
* Added link to Corti YouTube channel to website footer 